### PR TITLE
Fixes #5 - display a sensible link before badge is displayed

### DIFF
--- a/lib/lang/en/phrases/altmetric.xml
+++ b/lib/lang/en/phrases/altmetric.xml
@@ -6,5 +6,6 @@
 <epp:phrase id="lib/altmetric:unknown_error">An error has occured whilst retrieving data from Altmetric.</epp:phrase>
 
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:title">Altmetric</epp:phrase>
+<epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:default_content"><p><epc:pin name="default_link">View Altmetric information about this item</epc:pin>.</p></epp:phrase>
 
 </epp:phrases>

--- a/lib/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
@@ -28,7 +28,13 @@ sub render
 		
         my $div = $frag->appendChild( $session->make_element( 'div', id => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
 
-		$frag->appendChild( $session->make_javascript( <<EOJ ) );
+	my $phr = "default_content";
+	if( $session->get_lang->has_phrase( $self->html_phrase_id( $phr ) ) )
+	{
+		$div->appendChild( $self->html_phrase( $phr, default_link => $session->render_link( "https://www.altmetric.com/details/$type/$id" ) ) );
+	}
+
+	$frag->appendChild( $session->make_javascript( <<EOJ ) );
 new EP_Altmetric_Badge( 'altmetric_summary_page' );
 EOJ
 


### PR DESCRIPTION
New phrase to allow translations, and logic to check phrase exists before using it.