### PR TITLE
Fixes #9 by using phrase displayed on page before badge is added

### DIFF
--- a/lib/static/javascript/auto/99_altmetric.js
+++ b/lib/static/javascript/auto/99_altmetric.js
@@ -38,6 +38,9 @@ var EP_Altmetric_Badge = Class.create( {
 			return;
 		}
 
+		// get link text displayed before it is replaced by the badge (or use a default value)
+		var linktext = this.element.innerHTML.stripTags().strip().replace(/\n/g,' ').replace(/\s+/g,' ') || "View details on Altmetric's website";
+
 		var img = new Element( 'img', { 'src': json.images.medium, 'class': 'altmetric_donut' } );
 	
 		this.element.update( img ); 
@@ -87,7 +90,7 @@ var EP_Altmetric_Badge = Class.create( {
 		}
 		
 		var altlink = new Element( 'a', { 'href': json.details_url + '&domain=' + document.domain, 'class': 'altmetric_details', 'target': '_blank' } );
-		altlink.update( "View details on Altmetric's website" );
+		altlink.update( linktext );
 		
 		this.element.insert( new Element( 'div', { 'style' : 'clear:both' } ) );
 


### PR DESCRIPTION
Tested when the badge target is an empty div (results in fallback non-i18n text being used).