### PR TITLE
Re-work allowed_ids as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img align="right" height="200" src="altmetric_example.png">
 Display altmetric badges on summary pages. Visit the altmetric web-site for more information: http://www.altmetric.com/
 
-This plugin should work out-of-the-box. 
+The display of the badge is dependant on the EPrint record having a suitable identifier to display data for e.g. a DOI or ISBN
 
 There are some configuration options available, these are detailed in the z_altmetric.pl file.
 
@@ -12,11 +12,15 @@ Now maintained by *us* - eprintsug!
 
 ## Version history ##
 
-### Version 1.3.0 (not released yet) ###
+### Version 1.3.0 ###
+Released 2025-01
+
 - Adds user-agent in request made to Altmetric API
-- Displays default phrase (supports multiple languages) with link to Altmetric site before badge is displayed. See the [altmetric.xml phrase file](lib/lang/en/phrases/altmetric.xml#L9).
+- Displays a default phrase (supports multiple languages) with link to Altmetric site before badge is displayed. See the [altmetric.xml phrase file](lib/lang/en/phrases/altmetric.xml#L9).
 - Above phrase is also used when the badge is displayed 
-- If there is no Altmetric-supported identifier in the record, the EPrints Box is not rendered
+- If there is no Altmetric-supported identifiers in the record, the EPrints Box is not rendered
+- Uses the EPrints::DOI module to parse/format DOIs if the module is available
+- Limits the id_types that the cgi script will respond to. Defaults to DOI and ISBN. See comments in `cfg.d/z_altmetric.pl`
 
 If you add internationalised phrases to your repository and they don't appear to work, make sure the 'auto' javascript file has been reloaded.
 

--- a/cfg.d/z_altmetric.pl
+++ b/cfg.d/z_altmetric.pl
@@ -23,6 +23,11 @@ $c->{altmetric}->{base_url} = "https://api.altmetric.com/v1";
 # Function to return id type and id.
 # For supported id_types, check the Altmetrics API reference
 # Currently they support doi, isbn, arXivID, PMID, ads and uri.
+
+# These are the id_types we support. If the get_type_and_id function below will return other things,
+# please add them to this config.
+# $c->{altmetric}->{allowed_types} = [ 'doi', 'isbn' ];
+
 # If an Eprints has multiple usable identifiers, the first returned value will be used.
 $c->{altmetric}{get_type_and_id} = sub {
 	my( $eprint ) = @_;

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -13,20 +13,23 @@ my $alt_id = $repo->param( 'id' ) or exit;
 # Full list if types: citations id doi pmid arxiv ads uri isbn
 # We will stick to doi and isbn here and insist
 
-my @allowed_id_types = (qw/doi isbn/);
+my $allowed_id_types = $repo->config( "altmetric", "allowed_types" );
+# fall back to default if needed.
+$allowed_id_types = [qw/doi isbn/] if !defined $allowed_id_types;
 my $errmsg;
 
-unless ( grep {$_ eq $alt_type} @allowed_id_types ) {
-  $errmsg = $repo->phrase( 'lib/altmetric:not_found' );
-  print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
-  exit;
+unless ( grep {$_ eq $alt_type} @{$allowed_id_types} ) {
+	$errmsg = $repo->phrase( 'lib/altmetric:not_found' );
+	print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
+	exit;
 }
 
 my $ua = LWP::UserAgent->new();
+$ua->agent( 'eprints/' . EPrints->human_version );
 
 if( EPrints::Utils::is_set( $ENV{HTTP_proxy} ) )
 {
-        $ua->proxy( 'http', $ENV{HTTP_proxy} )
+	$ua->proxy( 'http', $ENV{HTTP_proxy} )
 }
 
 my $alt_url = URI->new( $repo->config( 'altmetric', 'base_url' )."/$alt_type/$alt_id" );
@@ -35,7 +38,7 @@ my $api_key = $repo->config( 'altmetric', 'api_key' );
 
 if( EPrints::Utils::is_set( $api_key ) )
 {
-        $alt_url->query_form( key => $api_key );
+	$alt_url->query_form( key => $api_key );
 }
 
 my $req = HTTP::Request->new( GET => $alt_url );
@@ -50,42 +53,41 @@ $repo->send_http_header( "content_type"=> "application/json; charset=utf-8" );
 
 if( $res->is_success )
 {
-        print STDOUT $res->content;
+	print STDOUT $res->content;
 }
 else
 {
-        # other error codes:
-        # 420: rate limited
-        # 502: API down for maintenance
-        # 403: unauthorised call
-        if( $res->code == 404 )
-        {
-                $errmsg = $repo->phrase( 'lib/altmetric:not_found' );
-        }
-        else
-        {
-              # We may be here because of an old version of LWP that is causing a security exception from the altmetric api
-              # In case that is the case, we will (re) sanitize the params and use curl
+	# other error codes:
+	# 420: rate limited
+	# 502: API down for maintenance
+	# 403: unauthorised call
+	if( $res->code == 404 )
+	{
+		$errmsg = $repo->phrase( 'lib/altmetric:not_found' );
+	}
+	else
+	{
+		# We may be here because of an old version of LWP that is causing a security exception from the altmetric api
+		# In case that is the case, we will (re) sanitize the params and use curl
+		if ($alt_type eq 'doi' ){
+			unless ( $alt_id =~ /10\.(\d+\.*)+[\/](([^\s\.])+\.*)+/  ) {
+				$errmsg = $repo->phrase( 'lib/altmetric:unknown_error' );
+				print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
+				exit;
+			}
+		}
 
-              if ($alt_type eq 'doi' ){
-                unless ( $alt_id =~ /10\.(\d+\.*)+[\/](([^\s\.])+\.*)+/  ) {
-                  $errmsg = $repo->phrase( 'lib/altmetric:unknown_error' );
-                  print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
-                  exit;
-                }
-              }
-
-              if ($alt_type eq 'isbn' ){
-                unless ( $alt_id =~ /(?=(?:\D*\d){10}(?:(?:\D*\d){3})?$)/ ) {
-                  $errmsg = $repo->phrase( 'lib/altmetric:unknown_error' );
-                  print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
-                  exit;
-                }
-              }
-              my $response = `curl -k "$alt_url"`;
-              print STDOUT $response;
-              exit;
-        }
+		if ($alt_type eq 'isbn' ){
+			unless ( $alt_id =~ /(?=(?:\D*\d){10}(?:(?:\D*\d){3})?$)/ ) {
+				$errmsg = $repo->phrase( 'lib/altmetric:unknown_error' );
+				print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
+				exit;
+			}
+		}
+		my $response = `curl -k "$alt_url"`;
+		print STDOUT $response;
+		exit;
+	}
 }
 
 exit;


### PR DESCRIPTION
The function defined in `cfg.d/z_altmetric.pl` allows you to return other id_types if you have them in your archive (and if they're supported by Altmetric).

Previously this was then restricted to only DOIs and ISBNs in the CGI script.
The above defaults are still there, but a config option to allow others to be added has been documented.

NB This is intended to form v1.3.0 of the Altmetric plugin.