### PR TITLE
V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,19 @@ Now maintained by *us* - eprintsug!
 
 ## Version history ##
 
-### Version 1.3.0 (not released yet) ###
+### Version 2.0.0
+- Updates description of some sources (twitter -> X) and adds new sources (Bluesky)
+- Improve accessibility by removing CSS before/after text
+- Renders details panel on server, allowing phrases to be used for better internationalisation
+- Uses `JSON` module to output content
+- Uses `EPrints::DOI` module if available when getting DOI from eprint
+
+
+See https://details-page-api-docs.altmetric.com/data-endpoints-counts.html#response-object and
+ https://help.altmetric.com/support/solutions/folders/6000237990 for details of 'cited by' data.
+
+
+### Version 1.3.0 (not released as an EPM) ###
 - Adds user-agent in request made to Altmetric API
 - Displays default phrase (supports multiple languages) with link to Altmetric site before badge is displayed. See the [altmetric.xml phrase file](lib/lang/en/phrases/altmetric.xml#L9).
 - Above phrase is also used when the badge is displayed 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Altmetric #
 
+**November 2025** The Altmetric API now _requires_ an API key. If an API key is not defined the plugin will
+now fall-back to the 'embed' method of adding a badge. This provides much of the same funcionality, although 
+does not support internationalisation that v2 of this extension does.
+
+Please see https://www.altmetric.com/solutions/free-tools/institutional-repository-badges/
+
 <img align="right" height="200" src="altmetric_example.png">
 Display altmetric badges on summary pages. Visit the altmetric web-site for more information: http://www.altmetric.com/
 
@@ -16,6 +22,7 @@ The colours used in the CSS are based on the following records which cover all c
 ## Version history ##
 
 ### Version 2.0.0 ###
+- Updates to spport API key being mandatory. Falls back to embed if key isn't defined.
 - Updates description of some sources (twitter -> X) and adds new sources (Bluesky)
 - Improve accessibility by removing CSS before/after text
 - Renders details panel on server, allowing phrases to be used for better internationalisation

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Altmetric #
 
+## Summery ##
+
+<img align="right" height="200" src="altmetric_example.png">
+Display altmetric badges for items with appropriate identifiers.
+
+Configuration options are detailed in the z_altmetric.pl file.
+
 Please see https://www.altmetric.com/solutions/free-tools/institutional-repository-badges/
 
-**November 2025** The Altmetric API now _requires_ an API key. If an API key is not defined the plugin will
+### November 2025 - v2.0.0 release ###
+The Altmetric API now _requires_ an API key. If an API key is not defined the plugin will
 now fall-back to the 'embed' method of adding a badge. This provides much of the same funcionality, although 
 does not support internationalisation that v2.0.0+ of this extension does.
 
@@ -17,10 +25,35 @@ $c->{altmetric}->{badge_attributes} = {
 };
 ```
 
-<img align="right" height="200" src="altmetric_example.png">
-Display altmetric badges on summary pages. Visit the altmetric web-site for more information: http://www.altmetric.com/
+Refer to https://badge-docs.altmetric.com/badge-playground.html for more details on the available options.
 
-There are some configuration options available, these are detailed in the z_altmetric.pl file.
+## Displaying the badge ##
+By default this plugin configures a 'Box' to be displayed on an item's summary page. The location and order of this box can be controlled
+with the 'appears'  parameter for the plugin:
+`$c->{plugins}->{"Screen::EPrint::Box::Altmetric"}->{appears}->{summary_bottom} = 25;`
+
+If your repository doesn't use boxes to display content on summary pages there are also EPScript functions to use:
+- `$item.altmetric_badge(1)` - the '1' parameter tests to see if an appropriate identifier is present in the record and a badge could be displayed
+- `$item.altmetric_badge()` - renders the badge - either using the API or embed method
+- `$item.altmetric_embed_script()` - inserts the embed javascript. This should only be included once on a page, and is not necessary if you are using
+the API-based badge display.
+
+Combining the above, an example that could be used on a summary page is:
+```xml
+<epc:if test="$item.altmetric_badge(1)">
+    <h2>Altmetric</h2>
+    <div id="summary_altmetric" class="panel panel-body">
+        <epc:print expr="$item.altmetric_embed_script()" />
+        <epc:print expr="$item.altmetric_badge()" />
+    </div>
+</epc:if>
+```
+
+The EPScript methods could also be used on e.g. view or search-result citations, but `$item.altmetric_embed_script()` should be omitted in the item citation
+and included on the page in a phrase or template using:
+```xml
+<epc:print expr="altmetric_embed_script()"/>
+```
 
 ## Colour palette ##
 The colours used on the Altmretic convey which sources contribute to the overall score.
@@ -29,6 +62,11 @@ The colours used in the CSS are based on the following records which cover all c
 - Clinical guideline: https://www.altmetric.com/details/40679400
 - Q&A: https://www.altmetric.com/details/1558157
 - Bluesky: https://www.altmetric.com/details/32695585
+
+## Useful DOIs for testing ##
+
+- 10.1038/s41586-018-0179-y
+- 10.1038/nature.2014.14583
 
 ## Version history ##
 
@@ -40,6 +78,7 @@ The colours used in the CSS are based on the following records which cover all c
 - Uses `JSON` module to output content
 - Uses `EPrints::DOI` module if available when getting DOI from eprint
 - Aligned colours with Altmetric site
+- Added EPScript methods to embed badges without use the 'Box'.
 
 See https://details-page-api-docs.altmetric.com/data-endpoints-counts.html#response-object and
  https://help.altmetric.com/support/solutions/folders/6000237990 for details of 'cited by' data.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # Altmetric #
 
+Please see https://www.altmetric.com/solutions/free-tools/institutional-repository-badges/
+
 **November 2025** The Altmetric API now _requires_ an API key. If an API key is not defined the plugin will
 now fall-back to the 'embed' method of adding a badge. This provides much of the same funcionality, although 
-does not support internationalisation that v2 of this extension does.
+does not support internationalisation that v2.0.0+ of this extension does.
 
-Please see https://www.altmetric.com/solutions/free-tools/institutional-repository-badges/
+If no API key is configured the badges displayed will use the attributes defined in the `cfg.d/z_altmetric.pl` file.
+By default these are:
+
+```perl
+$c->{altmetric}->{badge_attributes} = {
+        'data-badge-type'    => 'donut',
+        'data-badge-details' => 'right',
+        'data-condensed'     => 'true',
+};
+```
 
 <img align="right" height="200" src="altmetric_example.png">
 Display altmetric badges on summary pages. Visit the altmetric web-site for more information: http://www.altmetric.com/

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This version is available as both [an ingredient](https://github.com/eprintsug/a
 
 - If you have customised versions of the css or javascript files, please review these. If custom css was added to support other
   languages, please define this text in an appropriate language phrase file based on `en/altmetric.xml`
-- If badges are not displaying on summary pages you may need to refresh the astracts, either by running `bin/generate_abstracts` or
-  via the 'Regenerate abstracts' button on the Admin screen
+- After updating, you may need to refresh the abstracts, either by running `bin/generate_abstracts` or
+  via the 'Regenerate Abstracts' button on the Admin screen
 
 If you have issues, please ask on the EPrints tech list.
 
@@ -81,7 +81,7 @@ The colours used in the CSS are based on the following records which cover all c
 ## Version history ##
 
 ### Version 2.0.0 ###
-- Updates to spport API key being mandatory. Falls back to embed if key isn't defined.
+- Updates to support API key being mandatory. Falls back to embed method if an API key isn't defined.
 - Updates description of some sources (twitter -> X) and adds new sources (Bluesky)
 - Improve accessibility by removing CSS before/after text
 - Renders details panel on server, allowing phrases to be used for better internationalisation

--- a/README.md
+++ b/README.md
@@ -3,22 +3,25 @@
 <img align="right" height="200" src="altmetric_example.png">
 Display altmetric badges on summary pages. Visit the altmetric web-site for more information: http://www.altmetric.com/
 
-This plugin should work out-of-the-box. 
-
 There are some configuration options available, these are detailed in the z_altmetric.pl file.
 
-Originally developed by Sébastien François (https://github.com/sebastfr); updated by @drtjmb.
-Now maintained by *us* - eprintsug!
+## Colour palette ##
+The colours used on the Altmretic convey which sources contribute to the overall score.
+The colours used in the CSS are based on the following records which cover all current sources:
+- Most sources: https://www.altmetric.com/details/43673388
+- Clinical guideline: https://www.altmetric.com/details/40679400
+- Q&A: https://www.altmetric.com/details/1558157
+- Bluesky: https://www.altmetric.com/details/32695585
 
 ## Version history ##
 
-### Version 2.0.0
+### Version 2.0.0 ###
 - Updates description of some sources (twitter -> X) and adds new sources (Bluesky)
 - Improve accessibility by removing CSS before/after text
 - Renders details panel on server, allowing phrases to be used for better internationalisation
 - Uses `JSON` module to output content
 - Uses `EPrints::DOI` module if available when getting DOI from eprint
-
+- Aligned colours with Altmetric site
 
 See https://details-page-api-docs.altmetric.com/data-endpoints-counts.html#response-object and
  https://help.altmetric.com/support/solutions/folders/6000237990 for details of 'cited by' data.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Altmetric #
 
-## Summery ##
+## Summary ##
 
 <img align="right" height="200" src="altmetric_example.png">
 Display altmetric badges for items with appropriate identifiers.
@@ -26,6 +26,16 @@ $c->{altmetric}->{badge_attributes} = {
 ```
 
 Refer to https://badge-docs.altmetric.com/badge-playground.html for more details on the available options.
+
+### Upgrading to v2.0.0 ###
+This version is available as both [an ingredient](https://github.com/eprintsug/altmetric/tree/3_4) and an EPM in the Bazaar.
+
+- If you have customised versions of the css or javascript files, please review these. If custom css was added to support other
+  languages, please define this text in an appropriate language phrase file based on `en/altmetric.xml`
+- If badges are not displaying on summary pages you may need to refresh the astracts, either by running `bin/generate_abstracts` or
+  via the 'Regenerate abstracts' button on the Admin screen
+
+If you have issues, please ask on the EPrints tech list.
 
 ## Displaying the badge ##
 By default this plugin configures a 'Box' to be displayed on an item's summary page. The location and order of this box can be controlled

--- a/cfg.d/z_altmetric.pl
+++ b/cfg.d/z_altmetric.pl
@@ -1,4 +1,10 @@
 ### Altmetric Summary Page Widget
+# November 2025
+# Altmetric are now requiring a key when calling the API.
+# This extension has been re-written to use API-based methods if a key is defined, but
+# fall back to the embedded badges if not.
+#
+# ----------
 #
 # For the Altmetric badges to work properly you need to contact support@altmetric.com 
 # and give them the domain your IR is hosted on.
@@ -6,6 +12,10 @@
 #   e.g. only the most recent tweets or likes may be shown.
 #
 ########################################################################################
+
+
+# API key - see http://api.altmetric.com/index.html#keys
+#$c->{altmetric}->{api_key} = "";
 
 # Enable the widget
 $c->{plugins}{"Screen::EPrint::Box::Altmetric"}{params}{disable} = 0;
@@ -17,8 +27,6 @@ $c->{plugins}->{"Screen::EPrint::Box::Altmetric"}->{appears}->{summary_right} = 
 # Altmetric API URL
 $c->{altmetric}->{base_url} = "https://api.altmetric.com/v1";
 
-# Optional API key - see http://api.altmetric.com/index.html#keys
-# $c->{altmetric}->{api_key} = "";
 
 # These are the id_types we support. If the get_type_and_id function below will return other things
 # please add them to a config option:

--- a/cfg.d/z_altmetric.pl
+++ b/cfg.d/z_altmetric.pl
@@ -6,7 +6,7 @@
 #
 # ----------
 #
-# For the Altmetric badges to work properly you need to contact support@altmetric.com 
+# For the Altmetric badges to work properly you need to contact support@altmetric.com
 # and give them the domain your IR is hosted on.
 # If you skip this step users may not see the full details for each article
 #   e.g. only the most recent tweets or likes may be shown.
@@ -50,7 +50,7 @@ $c->{altmetric}->{base_url} = "https://api.altmetric.com/v1";
 # please add them to a config option:
 # $c->{altmetric}->{allowed_types} = [ 'doi', 'isbn' ];
 
-# If you want to change the order that the Altmetric sources are displayed in, or omit a source, 
+# If you want to change the order that the Altmetric sources are displayed in, or omit a source,
 # you can define the following config option (and change the order or remove members of it):
 # $c->{altmetric}->{sources} = [qw / fbwalls feeds gplus msm rdts qna tweeters bluesky wikipedia policies guidelines patents videos / ];
 #

--- a/cfg.d/z_altmetric.pl
+++ b/cfg.d/z_altmetric.pl
@@ -24,6 +24,12 @@ $c->{altmetric}->{base_url} = "https://api.altmetric.com/v1";
 # please add them to a config option:
 # $c->{altmetric}->{allowed_types} = [ 'doi', 'isbn' ];
 
+# If you want to change the order that the Altmetric sources are displayed in, or omit a source, 
+# you can define the following config option (and change the order or remove members of it):
+# $c->{altmetric}->{sources} = [qw / fbwalls feeds gplus msm rdts qna tweeters bluesky wikipedia policies guidelines patents videos / ];
+#
+# To change the text used to describe a source, please see the altmetric phrases file.
+
 # Function to return id type and id.
 # For supported id_types, check the Altmetrics API reference
 # Currently their API supports: doi, isbn, arXivID, PMID, ads and uri.

--- a/cfg.d/z_altmetric.pl
+++ b/cfg.d/z_altmetric.pl
@@ -20,9 +20,13 @@ $c->{altmetric}->{base_url} = "https://api.altmetric.com/v1";
 # Optional API key - see http://api.altmetric.com/index.html#keys
 # $c->{altmetric}->{api_key} = "";
 
+# These are the id_types we support. If the get_type_and_id function below will return other things
+# please add them to a config option:
+# $c->{altmetric}->{allowed_types} = [ 'doi', 'isbn' ];
+
 # Function to return id type and id.
 # For supported id_types, check the Altmetrics API reference
-# Currently they support doi, isbn, arXivID, PMID, ads and uri.
+# Currently their API supports: doi, isbn, arXivID, PMID, ads and uri.
 # If an Eprints has multiple usable identifiers, the first returned value will be used.
 $c->{altmetric}{get_type_and_id} = sub {
 	my( $eprint ) = @_;

--- a/cfg.d/z_altmetric.pl
+++ b/cfg.d/z_altmetric.pl
@@ -24,8 +24,26 @@ $c->{plugins}{"Screen::EPrint::Box::Altmetric"}{params}{disable} = 0;
 $c->{plugins}->{"Screen::EPrint::Box::Altmetric"}->{appears}->{summary_bottom} = 25;
 $c->{plugins}->{"Screen::EPrint::Box::Altmetric"}->{appears}->{summary_right} = undef;
 
+# If you are not using an API key, these are the attributes that will be used for the badge display.
+# Please see: https://badge-docs.altmetric.com/customizations.html#data-attributes, or try the
+# 'Badge generator': https://badge-docs.altmetric.com/badge-playground.html and copy the attributes
+# into this hash.
+#
+# The plugin will handle the identifier attribute (data-doi, data-isbn, data-arxiv-id etc.)
+$c->{altmetric}->{badge_attributes} = {
+	'data-badge-type'    => 'donut',
+	'data-badge-details' => 'right',
+	'data-condensed'     => 'true'.
+};
+
+
 # Altmetric API URL
 $c->{altmetric}->{base_url} = "https://api.altmetric.com/v1";
+
+# Altmetric Embed URL (only used when API key is not set)
+# There is a default value for this in the rendered box. If a different URL was needed
+# this can be defined here:
+# $c->{altmetric}->{embed_url} = "https://embed.altmetric.com/assets/embed.js";
 
 
 # These are the id_types we support. If the get_type_and_id function below will return other things

--- a/cfg.d/z_altmetric.pl
+++ b/cfg.d/z_altmetric.pl
@@ -33,7 +33,7 @@ $c->{plugins}->{"Screen::EPrint::Box::Altmetric"}->{appears}->{summary_right} = 
 $c->{altmetric}->{badge_attributes} = {
 	'data-badge-type'    => 'donut',
 	'data-badge-details' => 'right',
-	'data-condensed'     => 'true'.
+	'data-condensed'     => 'true',
 };
 
 

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -154,8 +154,11 @@ foreach my $s ( @$sources )
 {
 	if( defined $json->{"cited_by_${s}_count"} && $repo->get_lang->has_phrase( "lib/altmetric:cited_by_${s}", $repo ) )
 	{
+		my $phr_id = "lib/altmetric:cited_by_${s}";
+		$phr_id .= "_plural" if ( $json->{"cited_by_${s}_count"} > 1 && $repo->get_lang->has_phrase( "lib/altmetric:cited_by_${s}_plural", $repo ) );
+
 		my $r = $repo->make_element( "div", class => "altmetric_row altmetric_${s}" );
-		$r->appendChild( $repo->html_phrase( "lib/altmetric:cited_by_${s}", count => $repo->make_text( $json->{"cited_by_${s}_count"} ) ) );
+		$r->appendChild( $repo->html_phrase( $phr_id, count => $repo->make_text( $json->{"cited_by_${s}_count"} ) ) );
 		$d->appendChild( $r );
 	}
 }
@@ -168,8 +171,11 @@ if( defined $json->{"readers"} )
 	{
 		if( defined $json->{"readers"}->{$reader} && $json->{"readers"}->{$reader} > 0 && $repo->get_lang->has_phrase( "lib/altmetric:readers_${reader}", $repo ) )
 		{
+			my $phr_id = "lib/altmetric:readers_${reader}";
+			$phr_id .= "_plural" if ( $json->{"readers"}->{$reader} > 1 && $repo->get_lang->has_phrase( "lib/altmetric:readers_${reader}_plural", $repo ) );
+
 			my $r = $repo->make_element( "div", class => "altmetric_row altmetric_${reader}" );
-			$r->appendChild( $repo->html_phrase( "lib/altmetric:readers_${reader}", count => $repo->make_text( $json->{"readers"}->{$reader} ) ) );
+			$r->appendChild( $repo->html_phrase( $phr_id, count => $repo->make_text( $json->{"readers"}->{$reader} ) ) );
 			if( !$had_reader )
 			{
 				$d->appendChild( $repo->make_element( "br" ) );

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -1,7 +1,12 @@
 use LWP::UserAgent;
 use EPrints;
 
+use JSON;
+
 use strict;
+use warnings;
+
+use Data::Dumper;
 
 my $eprints = EPrints->new;
 my $repo = $eprints->current_repository;
@@ -13,16 +18,29 @@ my $alt_id = $repo->param( 'id' ) or exit;
 # Full list if types: citations id doi pmid arxiv ads uri isbn
 # We will stick to doi and isbn here and insist
 
-my @allowed_id_types = (qw/doi isbn/);
-my $errmsg;
+my $allowed_id_types = $repo->config( "altmetric", "allowed_types" );
+# fall back to default if needed.
+$allowed_id_types = [qw/doi isbn/] if !defined $allowed_id_types;
 
-unless ( grep {$_ eq $alt_type} @allowed_id_types ) {
-  $errmsg = $repo->phrase( 'lib/altmetric:not_found' );
-  print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
-  exit;
+my $sources = $repo->config( "altmetric", "sources" );
+$sources = [qw / fbwalls feeds gplus msm rdts qna tweeters bluesky wikipedia policies guidelines patents videos / ] if ! defined $sources;
+
+my $errmsg;
+my $out = {};
+
+binmode( STDOUT, ":utf8" );
+
+# note we always reply to the Ajax request with 200 OK
+EPrints::Apache::AnApache::send_status_line( $repo->get_request, 200 );
+$repo->send_http_header( "content_type"=> "application/json; charset=utf-8" );
+
+unless ( grep {$_ eq $alt_type} @{$allowed_id_types} ) {
+	return_error( $repo->phrase( 'lib/altmetric:not_found' ) );
+	exit;
 }
 
 my $ua = LWP::UserAgent->new();
+$ua->agent( 'eprints/' . EPrints->human_version );
 
 if( EPrints::Utils::is_set( $ENV{HTTP_proxy} ) )
 {
@@ -39,18 +57,12 @@ if( EPrints::Utils::is_set( $api_key ) )
 }
 
 my $req = HTTP::Request->new( GET => $alt_url );
-
 my $res = $ua->request($req);
-
-binmode( STDOUT, ":utf8" );
-
-# note we always reply to the Ajax request with 200 OK
-EPrints::Apache::AnApache::send_status_line( $repo->get_request, 200 );
-$repo->send_http_header( "content_type"=> "application/json; charset=utf-8" );
+my $c;
 
 if( $res->is_success )
 {
-        print STDOUT $res->content;
+	$c = $res->content;
 }
 else
 {
@@ -60,32 +72,103 @@ else
         # 403: unauthorised call
         if( $res->code == 404 )
         {
-                $errmsg = $repo->phrase( 'lib/altmetric:not_found' );
+		return_error( $repo->phrase( 'lib/altmetric:not_found' ) );
+		exit;
         }
         else
         {
-              # We may be here because of an old version of LWP that is causing a security exception from the altmetric api
-              # In case that is the case, we will (re) sanitize the params and use curl
+		# We may be here because of an old version of LWP that is causing a security exception from the altmetric api
+		# In case that is the case, we will (re) sanitize the params and use curl
 
-              if ($alt_type eq 'doi' ){
-                unless ( $alt_id =~ /10\.(\d+\.*)+[\/](([^\s\.])+\.*)+/  ) {
-                  $errmsg = $repo->phrase( 'lib/altmetric:unknown_error' );
-                  print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
-                  exit;
-                }
-              }
+		if( $alt_type eq 'doi' ){
+			unless ( $alt_id =~ /10\.(\d+\.*)+[\/](([^\s\.])+\.*)+/  ) {
+				return_error( $repo->phrase( 'lib/altmetric:bad_id' ) );
+				exit;
+			}
+		}
+		elsif( $alt_type eq 'isbn' )
+		{
+			unless ( $alt_id =~ /(?=(?:\D*\d){10}(?:(?:\D*\d){3})?$)/ ) {
+				return_error( $repo->phrase( 'lib/altmetric:bad_id' ) );
+				exit;
+			}
+		}
+	}
 
-              if ($alt_type eq 'isbn' ){
-                unless ( $alt_id =~ /(?=(?:\D*\d){10}(?:(?:\D*\d){3})?$)/ ) {
-                  $errmsg = $repo->phrase( 'lib/altmetric:unknown_error' );
-                  print STDOUT '{ "error": "1", "message": "'.$errmsg.'" }';
-                  exit;
-                }
-              }
-              my $response = `curl -k "$alt_url"`;
-              print STDOUT $response;
-              exit;
-        }
+	$c = `curl -k "$alt_url"`;
 }
 
+my $json = eval { decode_json( $c ) };
+if( $@ )
+{
+	# Don't send the error message to the browser - but log it
+        print STDERR "Altmetric: broken JSON from API ($alt_type --> $alt_id)\n", $@;
+
+	return_error( $repo->phrase( 'lib/altmetric:json_decode_error' ) );
+	exit;
+}
+
+# This will be converted to a json string
+my $f = $repo->make_doc_fragment();
+
+if( defined $json->{images}->{medium} )
+{
+	# the altmetric score shown on the badge is rounded up. Ceil here matches that score.
+	my $score = defined $json->{score} ? "Altmetric score: ".POSIX::ceil($json->{score}) : ''; 
+	my $img = $repo->make_element( "img", src => $json->{images}->{medium}, class => 'altmetric_donut', alt => $score );
+	$f->appendChild( $img );
+}
+
+my $d = $repo->make_element( "div", class => "altmetric_details_panel" );
+$f->appendChild( $d );
+foreach my $s ( @$sources )
+{
+	if( defined $json->{"cited_by_${s}_count"} && $repo->get_lang->has_phrase( "lib/altmetric:cited_by_${s}", $repo ) )
+	{
+		my $r = $repo->make_element( "div", class => "altmetric_row altmetric_${s}" );
+		$r->appendChild( $repo->html_phrase( "lib/altmetric:cited_by_${s}", count => $repo->make_text( $json->{"cited_by_${s}_count"} ) ) );
+		$d->appendChild( $r );
+	}
+}
+
+if( defined $json->{"readers"} )
+{
+	my $had_reader = 0;
+
+	foreach my $reader ( qw / mendeley citeulike / )
+	{
+		if( defined $json->{"readers"}->{$reader} && $json->{"readers"}->{$reader} > 0 && $repo->get_lang->has_phrase( "lib/altmetric:readers_${reader}", $repo ) )
+		{
+			my $r = $repo->make_element( "div", class => "altmetric_row altmetric_${reader}" );
+			$r->appendChild( $repo->html_phrase( "lib/altmetric:readers_${reader}", count => $repo->make_text( $json->{"readers"}->{$reader} ) ) );
+			if( !$had_reader )
+			{
+				$d->appendChild( $repo->make_element( "br" ) );
+				$had_reader = 1;
+			}
+			$d->appendChild( $r );
+		}
+	}
+}
+
+# to_string used because it removes unnecessary namespaces
+$out->{html} = EPrints::XML::to_string( $f, "utf-8", 1 );
+EPrints::XML::dispose( $f );
+
+# This is used to provide a link to more details
+$out->{details_url} = $json->{'details_url'};
+
+print STDOUT encode_json( $out );
 exit;
+
+sub return_error
+{
+	my( $err_msg ) = @_;
+
+	my $out = {};
+	$out->{error} = 1;
+	$out->{message} = $err_msg;
+
+	print STDOUT encode_json( $out );
+	
+}

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -51,7 +51,7 @@ $ua->agent( 'eprints/' . EPrints->human_version );
 
 if( EPrints::Utils::is_set( $ENV{HTTP_proxy} ) )
 {
-        $ua->proxy( 'http', $ENV{HTTP_proxy} )
+	$ua->proxy( 'http', $ENV{HTTP_proxy} )
 }
 
 my $alt_url = URI->new( $repo->config( 'altmetric', 'base_url' )."/$alt_type/$alt_id" );
@@ -59,7 +59,7 @@ my $alt_url = URI->new( $repo->config( 'altmetric', 'base_url' )."/$alt_type/$al
 
 if( EPrints::Utils::is_set( $api_key ) )
 {
-        $alt_url->query_form( key => $api_key );
+	$alt_url->query_form( key => $api_key );
 }
 
 my $req = HTTP::Request->new( GET => $alt_url );
@@ -72,28 +72,28 @@ if( $res->is_success )
 }
 else
 {
-        # other error codes (from: https://details-page-api-docs.altmetric.com/shared/status-codes.html):
+	# other error codes (from: https://details-page-api-docs.altmetric.com/shared/status-codes.html):
 	# 401: Auth reqd.
 	# 403: Forbidden
 	# 404: Not found
-        # 429: rate limited
-        # 502: API down for maintenance
+	# 429: rate limited
+	# 502: API down for maintenance
 	if( $res->code == 401 )
 	{
 		# This could either be a 'need to provide a key' or 'API key was wrong'
 		return_error( $repo->phrase( 'lib/altmetric:auth_reqd' ) . "\n" . $res->content );
 		exit;
 	}
-        elsif( $res->code == 403 )
-        {
+	elsif( $res->code == 403 )
+	{
 		return_error( $repo->phrase( 'lib/altmetric:forbidden' ) );
 		exit;
-        }
-        elsif( $res->code == 404 )
-        {
+	}
+	elsif( $res->code == 404 )
+	{
 		return_error( $repo->phrase( 'lib/altmetric:not_found' ) );
 		exit;
-        }
+	}
 	elsif( $res->code == 429 )
 	{
 		return_error( $repo->phrase( 'lib/altmetric:rate_limited' ) );
@@ -104,8 +104,8 @@ else
 		return_error( $repo->phrase( 'lib/altmetric:down_for_maintenance' ) );
 		exit;
 	}
-        else
-        {
+	else
+	{
 		# We may be here because of an old version of LWP that is causing a security exception from the altmetric api
 		# In case that is the case, we will (re) sanitize the params and use curl
 
@@ -131,7 +131,7 @@ my $json = eval { decode_json( $c ) };
 if( $@ )
 {
 	# Don't send the error message to the browser - but log it
-        print STDERR "Altmetric: broken JSON from API ($alt_type --> $alt_id)\n", $@;
+	print STDERR "Altmetric: broken JSON from API ($alt_type --> $alt_id)\n", $@;
 
 	return_error( $repo->phrase( 'lib/altmetric:json_decode_error' ) );
 	exit;
@@ -143,7 +143,7 @@ my $f = $repo->make_doc_fragment();
 if( defined $json->{images}->{medium} )
 {
 	# the altmetric score shown on the badge is rounded up. Ceil here matches that score.
-	my $score = defined $json->{score} ? "Altmetric score: ".POSIX::ceil($json->{score}) : ''; 
+	my $score = defined $json->{score} ? "Altmetric score: ".POSIX::ceil($json->{score}) : '';
 	my $img = $repo->make_element( "img", src => $json->{images}->{medium}, class => 'altmetric_donut', alt => $score );
 	$f->appendChild( $img );
 }

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -13,8 +13,6 @@ exit( 0 ) unless( defined $repo );
 my $alt_type = $repo->param( 'id_type' ) or exit;
 my $alt_id = $repo->param( 'id' ) or exit;
 
-# API key now mandatory. 
-my $api_key = $repo->config( 'altmetric', 'api_key' ) or exit;
 
 # Full list if types: citations id doi pmid arxiv ads uri isbn
 
@@ -34,6 +32,14 @@ binmode( STDOUT, ":utf8" );
 # note we always reply to the Ajax request with 200 OK
 EPrints::Apache::AnApache::send_status_line( $repo->get_request, 200 );
 $repo->send_http_header( "content_type"=> "application/json; charset=utf-8" );
+
+# API key now mandatory.
+my $api_key = $repo->config( 'altmetric', 'api_key' );
+if( !defined $api_key )
+{
+	return_error( $repo->phrase( 'lib/altmetric:auth_reqd' ) );
+	exit;
+}
 
 unless ( grep {$_ eq $alt_type} @{$allowed_id_types} ) {
 	return_error( $repo->phrase( 'lib/altmetric:not_found' ) );

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -78,9 +78,15 @@ else
         # 403: unauthorised call
 	if( $res->code == 401 )
 	{
+		# This could either be a 'need to provide a key' or 'API key was wrong'
 		return_error( $repo->phrase( 'lib/altmetric:auth_reqd' ) . "\n" . $res->content );
 		exit;
 	}
+        elsif( $res->code == 403 )
+        {
+		return_error( $repo->phrase( 'lib/altmetric:forbidden' ) );
+		exit;
+        }
         elsif( $res->code == 404 )
         {
 		return_error( $repo->phrase( 'lib/altmetric:not_found' ) );

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -6,8 +6,6 @@ use JSON;
 use strict;
 use warnings;
 
-use Data::Dumper;
-
 my $eprints = EPrints->new;
 my $repo = $eprints->current_repository;
 exit( 0 ) unless( defined $repo );
@@ -70,7 +68,12 @@ else
         # 420: rate limited
         # 502: API down for maintenance
         # 403: unauthorised call
-        if( $res->code == 404 )
+	if( $res->code == 403 )
+	{
+		return_error( $repo->phrase( 'lib/altmetric:auth_reqd' ) ); #TODO add message from Altmetric API too?
+		exit;
+	}
+        elsif( $res->code == 404 )
         {
 		return_error( $repo->phrase( 'lib/altmetric:not_found' ) );
 		exit;

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -13,13 +13,16 @@ exit( 0 ) unless( defined $repo );
 my $alt_type = $repo->param( 'id_type' ) or exit;
 my $alt_id = $repo->param( 'id' ) or exit;
 
+# API key now mandatory. 
+my $api_key = $repo->config( 'altmetric', 'api_key' ) or exit;
+
 # Full list if types: citations id doi pmid arxiv ads uri isbn
-# We will stick to doi and isbn here and insist
 
 my $allowed_id_types = $repo->config( "altmetric", "allowed_types" );
 # fall back to default if needed.
 $allowed_id_types = [qw/doi isbn/] if !defined $allowed_id_types;
 
+# Details to be displayed if they have any score.
 my $sources = $repo->config( "altmetric", "sources" );
 $sources = [qw / fbwalls feeds gplus msm rdts qna tweeters bluesky wikipedia policies guidelines patents videos / ] if ! defined $sources;
 
@@ -47,7 +50,6 @@ if( EPrints::Utils::is_set( $ENV{HTTP_proxy} ) )
 
 my $alt_url = URI->new( $repo->config( 'altmetric', 'base_url' )."/$alt_type/$alt_id" );
 
-my $api_key = $repo->config( 'altmetric', 'api_key' );
 
 if( EPrints::Utils::is_set( $api_key ) )
 {
@@ -68,9 +70,9 @@ else
         # 420: rate limited
         # 502: API down for maintenance
         # 403: unauthorised call
-	if( $res->code == 403 )
+	if( $res->code == 401 )
 	{
-		return_error( $repo->phrase( 'lib/altmetric:auth_reqd' ) ); #TODO add message from Altmetric API too?
+		return_error( $repo->phrase( 'lib/altmetric:auth_reqd' ) . "\n" . $res->content );
 		exit;
 	}
         elsif( $res->code == 404 )
@@ -78,6 +80,11 @@ else
 		return_error( $repo->phrase( 'lib/altmetric:not_found' ) );
 		exit;
         }
+	elsif( $res->code == 420 )
+	{
+		return_error( $repo->phrase( 'lib/altmetric:rate_limited' ) );
+		exit;
+	}
         else
         {
 		# We may be here because of an old version of LWP that is causing a security exception from the altmetric api

--- a/cgi/altmetric
+++ b/cgi/altmetric
@@ -72,10 +72,12 @@ if( $res->is_success )
 }
 else
 {
-        # other error codes:
-        # 420: rate limited
+        # other error codes (from: https://details-page-api-docs.altmetric.com/shared/status-codes.html):
+	# 401: Auth reqd.
+	# 403: Forbidden
+	# 404: Not found
+        # 429: rate limited
         # 502: API down for maintenance
-        # 403: unauthorised call
 	if( $res->code == 401 )
 	{
 		# This could either be a 'need to provide a key' or 'API key was wrong'
@@ -92,9 +94,14 @@ else
 		return_error( $repo->phrase( 'lib/altmetric:not_found' ) );
 		exit;
         }
-	elsif( $res->code == 420 )
+	elsif( $res->code == 429 )
 	{
 		return_error( $repo->phrase( 'lib/altmetric:rate_limited' ) );
+		exit;
+	}
+	elsif( $res->code == 502 )
+	{
+		return_error( $repo->phrase( 'lib/altmetric:down_for_maintenance' ) );
 		exit;
 	}
         else
@@ -116,8 +123,8 @@ else
 			}
 		}
 	}
-
-	$c = `curl -k "$alt_url"`;
+	# Opts: s = silent; S = but still report errors; k = insecure
+	$c = `curl -sSk "$alt_url"`;
 }
 
 my $json = eval { decode_json( $c ) };

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -3,8 +3,8 @@
 <epp:phrases xmlns="http://www.w3.org/1999/xhtml" xmlns:epp="http://eprints.org/ep3/phrase" xmlns:epc="http://eprints.org/ep3/control">
 
 <epp:phrase id="lib/altmetric:not_found">No Altmetrics are currently available for this publication.</epp:phrase>
-<epp:phrase id="lib/altmetric:auth_reqd">The Altmetrics API now requires a key. Please refer to the EPrints/Altmetric documenation.</epp:phrase>
-<epp:phrase id="lib/altmetric:forbidden">No access to the Altmetrics API.</epp:phrase>
+<epp:phrase id="lib/altmetric:auth_reqd">The Altmetric API now requires a key. Please refer to the EPrints/Altmetric documentation.</epp:phrase>
+<epp:phrase id="lib/altmetric:forbidden">No access to the Altmetric API.</epp:phrase>
 <epp:phrase id="lib/altmetric:rate_limited">Too many requests - rate limited.</epp:phrase>
 <epp:phrase id="lib/altmetric:unknown_error">An error has occurred whilst retrieving data from Altmetric.</epp:phrase>
 

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -4,6 +4,7 @@
 
 <epp:phrase id="lib/altmetric:not_found">No Altmetrics are currently available for this publication.</epp:phrase>
 <epp:phrase id="lib/altmetric:auth_reqd">The Altmetrics API now requires a key. Please refer to the EPrints/Altmetric documenation.</epp:phrase>
+<epp:phrase id="lib/altmetric:forbidden">No access to the Altmetrics API.</epp:phrase>
 <epp:phrase id="lib/altmetric:rate_limited">Too many requests - rate limited.</epp:phrase>
 <epp:phrase id="lib/altmetric:unknown_error">An error has occurred whilst retrieving data from Altmetric.</epp:phrase>
 

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -15,7 +15,7 @@
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:title">Altmetric</epp:phrase>
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:default_content"><p><epc:pin name="default_link">View Altmetric information about this item</epc:pin>.</p></epp:phrase>
 
-<!-- Each phrase below has a singular (e.g. 'user') and plural (e.g. 'users') variant. In English, for most cases, 
+<!-- Each phrase below has a singular (e.g. 'user') and plural (e.g. 'users') variant. In English, for most cases,
 	this can be achieved by adding an 's' on at the end, so the singular phrase is used (with the pin passed-through).
 	One exception below is 'policy' vs. 'policies'.
 

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -8,4 +8,21 @@
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:title">Altmetric</epp:phrase>
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:default_content"><p><epc:pin name="default_link">View Altmetric information about this item</epc:pin>.</p></epp:phrase>
 
+<!-- https://details-page-api-docs.altmetric.com/data-endpoints-counts.html#response-object -->
+<epp:phrase id="lib/altmetric:cited_by_bluesky"><span><epc:pin name="count" /></span> bluesky users</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_fbwalls"><span><epc:pin name="count" /></span> Facebook pages</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_feeds"><span><epc:pin name="count" /></span> blogs</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_gplus"><span><epc:pin name="count" /></span> Google+ users</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_guidelines"><span><epc:pin name="count" /></span> guidelines</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_msm"><span><epc:pin name="count" /></span> news outlets</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_patents"><span><epc:pin name="count" /></span> patents</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_policies"><span><epc:pin name="count" /></span> policies</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_qna"><span><epc:pin name="count" /></span> Q&amp;A pages</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_rdts"><span><epc:pin name="count" /></span> Redditors</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_tweeters"><span><epc:pin name="count" /></span> X users</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_videos"><span><epc:pin name="count" /></span> YouTube creators</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_wikipedia"><span><epc:pin name="count" /></span> Wikipedia pages</epp:phrase>
+
+<epp:phrase id="lib/altmetric:readers_mendeley"><span><epc:pin name="count" /></span> Mendeley users</epp:phrase>
+
 </epp:phrases>

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -5,6 +5,9 @@
 <epp:phrase id="lib/altmetric:not_found">No Altmetrics are currently available for this publication.</epp:phrase>
 <epp:phrase id="lib/altmetric:unknown_error">An error has occurred whilst retrieving data from Altmetric.</epp:phrase>
 
+<epp:phrase id="lib/altmetric:bad_id">No Altmetrics are currently available for this publication. This may be due to an issue with the identifier.</epp:phrase>
+<epp:phrase id="lib/altmetric:json_decode_error">There was a problem with the Altmetric data. This has been logged.</epp:phrase>
+
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:title">Altmetric</epp:phrase>
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:default_content"><p><epc:pin name="default_link">View Altmetric information about this item</epc:pin>.</p></epp:phrase>
 

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -4,6 +4,7 @@
 
 <epp:phrase id="lib/altmetric:not_found">No Altmetrics are currently available for this publication.</epp:phrase>
 <epp:phrase id="lib/altmetric:auth_reqd">The Altmetrics API now requires a key. Please refer to the EPrints/Altmetric documenation.</epp:phrase>
+<epp:phrase id="lib/altmetric:rate_limited">Too many requests - rate limited.</epp:phrase>
 <epp:phrase id="lib/altmetric:unknown_error">An error has occurred whilst retrieving data from Altmetric.</epp:phrase>
 
 <epp:phrase id="lib/altmetric:bad_id">No Altmetrics are currently available for this publication. This may be due to an issue with the identifier.</epp:phrase>

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -22,7 +22,7 @@
 	See https://details-page-api-docs.altmetric.com/data-endpoints-counts.html#response-object for details of the
 	data available in the API response.
 -->
-<epp:phrase id="lib/altmetric:cited_by_bluesky"><span><epc:pin name="count" /></span> bluesky user</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_bluesky"><span><epc:pin name="count" /></span> Bluesky user</epp:phrase>
 <epp:phrase id="lib/altmetric:cited_by_bluesky_plural"><epc:phrase ref="lib/altmetric:cited_by_bluesky"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
 
 <epp:phrase id="lib/altmetric:cited_by_fbwalls"><span><epc:pin name="count" /></span> Facebook page</epp:phrase>

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -15,21 +15,54 @@
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:title">Altmetric</epp:phrase>
 <epp:phrase id="Plugin/Screen/EPrint/Box/Altmetric:default_content"><p><epc:pin name="default_link">View Altmetric information about this item</epc:pin>.</p></epp:phrase>
 
-<!-- https://details-page-api-docs.altmetric.com/data-endpoints-counts.html#response-object -->
-<epp:phrase id="lib/altmetric:cited_by_bluesky"><span><epc:pin name="count" /></span> bluesky users</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_fbwalls"><span><epc:pin name="count" /></span> Facebook pages</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_feeds"><span><epc:pin name="count" /></span> blogs</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_gplus"><span><epc:pin name="count" /></span> Google+ users</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_guidelines"><span><epc:pin name="count" /></span> guidelines</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_msm"><span><epc:pin name="count" /></span> news outlets</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_patents"><span><epc:pin name="count" /></span> patents</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_policies"><span><epc:pin name="count" /></span> policies</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_qna"><span><epc:pin name="count" /></span> Q&amp;A pages</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_rdts"><span><epc:pin name="count" /></span> Redditors</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_tweeters"><span><epc:pin name="count" /></span> X users</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_videos"><span><epc:pin name="count" /></span> YouTube creators</epp:phrase>
-<epp:phrase id="lib/altmetric:cited_by_wikipedia"><span><epc:pin name="count" /></span> Wikipedia pages</epp:phrase>
+<!-- Each phrase below has a singular (e.g. 'user') and plural (e.g. 'users') variant. In English, for most cases, 
+	this can be achieved by adding an 's' on at the end, so the singular phrase is used (with the pin passed-through).
+	One exception below is 'policy' vs. 'policies'.
 
-<epp:phrase id="lib/altmetric:readers_mendeley"><span><epc:pin name="count" /></span> Mendeley users</epp:phrase>
+	See https://details-page-api-docs.altmetric.com/data-endpoints-counts.html#response-object for details of the
+	data available in the API response.
+-->
+<epp:phrase id="lib/altmetric:cited_by_bluesky"><span><epc:pin name="count" /></span> bluesky user</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_bluesky_plural"><epc:phrase ref="lib/altmetric:cited_by_bluesky"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_fbwalls"><span><epc:pin name="count" /></span> Facebook page</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_fbwalls_plural"><epc:phrase ref="lib/altmetric:cited_by_fbwalls"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_feeds"><span><epc:pin name="count" /></span> blog</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_feeds_plural"><epc:phrase ref="lib/altmetric:cited_by_feeds"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_gplus"><span><epc:pin name="count" /></span> Google+ user</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_gplus_plural"><epc:phrase ref="lib/altmetric:cited_by_gplus"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_guidelines"><span><epc:pin name="count" /></span> guideline</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_guidelines_plural"><epc:phrase ref="lib/altmetric:cited_by_guidelines"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_msm"><span><epc:pin name="count" /></span> news outlet</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_msm_plural"><epc:phrase ref="lib/altmetric:cited_by_msm"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_patents"><span><epc:pin name="count" /></span> patent</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_patents_plural"><epc:phrase ref="lib/altmetric:cited_by_patents"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_policies"><span><epc:pin name="count" /></span> policy</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_policies_plural"><span><epc:pin name="count" /></span> policies</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_qna"><span><epc:pin name="count" /></span> Q&amp;A page</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_qna_plural"><epc:phrase ref="lib/altmetric:cited_by_qna"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_rdts"><span><epc:pin name="count" /></span> Redditor</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_rdts_plural"><epc:phrase ref="lib/altmetric:cited_by_rdts"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_tweeters"><span><epc:pin name="count" /></span> X user</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_tweeters_plural"><epc:phrase ref="lib/altmetric:cited_by_tweeters"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_videos"><span><epc:pin name="count" /></span> YouTube creator</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_videos_plural"><epc:phrase ref="lib/altmetric:cited_by_videos"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<epp:phrase id="lib/altmetric:cited_by_wikipedia"><span><epc:pin name="count" /></span> Wikipedia page</epp:phrase>
+<epp:phrase id="lib/altmetric:cited_by_wikipedia_plural"><epc:phrase ref="lib/altmetric:cited_by_wikipedia"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
+
+<!-- Readers -->
+<epp:phrase id="lib/altmetric:readers_mendeley"><span><epc:pin name="count" /></span> Mendeley user</epp:phrase>
+<epp:phrase id="lib/altmetric:readers_mendeley_plural"><epc:phrase ref="lib/altmetric:readers_mendeley"><epc:param name="count"><epc:pin name="count" /></epc:param></epc:phrase>s</epp:phrase>
 
 </epp:phrases>

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -3,6 +3,7 @@
 <epp:phrases xmlns="http://www.w3.org/1999/xhtml" xmlns:epp="http://eprints.org/ep3/phrase" xmlns:epc="http://eprints.org/ep3/control">
 
 <epp:phrase id="lib/altmetric:not_found">No Altmetrics are currently available for this publication.</epp:phrase>
+<epp:phrase id="lib/altmetric:auth_reqd">The Altmetrics API now requires a key. Please refer to the EPrints/Altmetric documenation.</epp:phrase>
 <epp:phrase id="lib/altmetric:unknown_error">An error has occurred whilst retrieving data from Altmetric.</epp:phrase>
 
 <epp:phrase id="lib/altmetric:bad_id">No Altmetrics are currently available for this publication. This may be due to an issue with the identifier.</epp:phrase>

--- a/lang/en/phrases/altmetric.xml
+++ b/lang/en/phrases/altmetric.xml
@@ -6,6 +6,7 @@
 <epp:phrase id="lib/altmetric:auth_reqd">The Altmetric API now requires a key. Please refer to the EPrints/Altmetric documentation.</epp:phrase>
 <epp:phrase id="lib/altmetric:forbidden">No access to the Altmetric API.</epp:phrase>
 <epp:phrase id="lib/altmetric:rate_limited">Too many requests - rate limited.</epp:phrase>
+<epp:phrase id="lib/altmetric:down_for_maintenance">Altmetric unavailable due to maintenance.</epp:phrase>
 <epp:phrase id="lib/altmetric:unknown_error">An error has occurred whilst retrieving data from Altmetric.</epp:phrase>
 
 <epp:phrase id="lib/altmetric:bad_id">No Altmetrics are currently available for this publication. This may be due to an issue with the identifier.</epp:phrase>

--- a/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
+++ b/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
@@ -35,7 +35,8 @@ sub render
 
 	if( defined $session->config( "altmetric", "api_key" ) )
 	{
-		my $div = $frag->appendChild( $session->make_element( 'div', class => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
+		my $t = EPrints::Utils::generate_token( 8 );
+		my $div = $frag->appendChild( $session->make_element( 'div', id => "altmetric_summary_page_$t", class => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
 
 		my $phr = "default_content";
 		if( $session->get_lang->has_phrase( $self->html_phrase_id( $phr ) ) )
@@ -44,7 +45,7 @@ sub render
 		}
 
 		$frag->appendChild( $session->make_javascript( <<EOJ ) );
-new EP_Altmetric_Badge( 'altmetric_summary_page' );
+new EP_Altmetric_Badge( 'altmetric_summary_page_$t' );
 EOJ
 
 	}

--- a/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
+++ b/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
@@ -53,8 +53,7 @@ EOJ
 	{
 		my $div = $session->make_element( 'div',
 			class => 'altmetric-embed',
-			"data-altmetric-id-type" => $type,
-			"data-altmetric-id" => $id,
+			"data-$type" => $id,
 			( defined $session->config( "altmetric", "badge_attributes" ) ? %{$session->config( "altmetric", "badge_attributes" )} : undef ),
 		);
 		$frag->appendChild( $div );

--- a/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
+++ b/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
@@ -33,7 +33,7 @@ sub render
 	# If an API key has been defined, use the API (via local cgi) method to render the data.
 	# If there is no API key, fall back to the Altmetric embed javascript method.
 
-	if( defined $session->config( "altmetric", "api_key" ) )
+	if( EPrints::Utils::is_set( $session->config( "altmetric", "api_key" ) ) )
 	{
 		my $t = EPrints::Utils::generate_token( 8 );
 		my $div = $frag->appendChild( $session->make_element( 'div', id => "altmetric_summary_page_$t", class => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
@@ -120,8 +120,6 @@ sub run_altmetric_embed_script
 {
 	my( $self, $state ) = @_;
 
-	#my $box = $state->{session}->plugin( "Screen::EPrint::Box::Altmetric", processor => $processor );
-	#my $box = $state->{session}->plugin( "Screen::EPrint::Box::Altmetric", session => $state->{session} );
 	my $box = $state->{session}->plugin( "Screen::EPrint::Box::Altmetric" );
 
 	if( !defined $box )

--- a/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
+++ b/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
@@ -69,7 +69,7 @@ sub render_embed_script
 {
 	my( $self ) = @_;
 
-        my $session = $self->{session};
+	my $session = $self->{session};
 
 	my $script = $session->make_element( "script",
 		src =>( defined $session->config( "altmetric", "embed_url" )
@@ -81,7 +81,7 @@ sub render_embed_script
 	return $script;
 }
 
-# These methods may be useful if the badge should be 
+# These methods may be useful if the badge should be
 
 package EPrints::Script::Compiled;
 

--- a/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
+++ b/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
@@ -14,7 +14,6 @@ sub can_be_viewed
 	# prevent box being rendered if type or id are not available
 	my ( $type, $id ) = $self->{session}->call( [ "altmetric", "get_type_and_id" ], $self->{processor}->{eprint} );
 	return 0 if ( !defined $type || !defined $id );
-
 		
         return 1;
 }
@@ -30,18 +29,44 @@ sub render
         my ( $type, $id ) = $session->call( [ "altmetric", "get_type_and_id" ], $self->{processor}->{eprint} );
 
         return $frag if ( !defined $type || !defined $id );
-		
-        my $div = $frag->appendChild( $session->make_element( 'div', id => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
 
-	my $phr = "default_content";
-	if( $session->get_lang->has_phrase( $self->html_phrase_id( $phr ) ) )
+	# If an API key has been defined, use the API (via local cgi) method to render the data.
+	# If there is no API key, fall back to the Altmetric embed javascript method.
+
+	if( defined $session->config( "altmetric", "api_key" ) )
 	{
-		$div->appendChild( $self->html_phrase( $phr, default_link => $session->render_link( "https://www.altmetric.com/details/$type/$id" ) ) );
-	}
+        	my $div = $frag->appendChild( $session->make_element( 'div', id => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
 
-	$frag->appendChild( $session->make_javascript( <<EOJ ) );
+		my $phr = "default_content";
+		if( $session->get_lang->has_phrase( $self->html_phrase_id( $phr ) ) )
+		{
+			$div->appendChild( $self->html_phrase( $phr, default_link => $session->render_link( "https://www.altmetric.com/details/$type/$id" ) ) );
+		}
+
+		$frag->appendChild( $session->make_javascript( <<EOJ ) );
 new EP_Altmetric_Badge( 'altmetric_summary_page' );
 EOJ
+
+	}
+	else
+	{
+        	my $div = $session->make_element( 'div',
+			id => 'altmetric_summary_page',
+			"data-altmetric-id-type" => $type,
+			"data-altmetric-id" => $id,
+			( defined $session->config( "altmetric", "badge_attributes" ) ? %{$session->config( "altmetric", "badge_attributes" )} : undef ),
+		);
+		$frag->appendChild( $div );
+
+		my $script = $session->make_element( "script",
+                        src =>( defined $session->config( "altmetric", "embed_url" )
+                                ? $session->config( "altmetric", "embed_url" )
+                                : "https://embed.altmetric.com/assets/embed.js"
+                        ),
+                        type => 'text/javascript',
+                );
+                $frag->appendChild( $script );
+	}
 
         return $frag;
 }

--- a/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
+++ b/plugins/EPrints/Plugin/Screen/EPrint/Box/Altmetric.pm
@@ -6,36 +6,36 @@ use strict;
 
 sub can_be_viewed
 {
-        my( $self ) = @_;
+	my( $self ) = @_;
 
-        return 0 if( !defined $self->{processor}->{eprint} );
-        return 0 if( !$self->{session}->can_call( "altmetric", "get_type_and_id" ) );
+	return 0 if( !defined $self->{processor}->{eprint} );
+	return 0 if( !$self->{session}->can_call( "altmetric", "get_type_and_id" ) );
 
 	# prevent box being rendered if type or id are not available
 	my ( $type, $id ) = $self->{session}->call( [ "altmetric", "get_type_and_id" ], $self->{processor}->{eprint} );
 	return 0 if ( !defined $type || !defined $id );
-		
-        return 1;
+
+	return 1;
 }
 
 sub render
 {
-        my( $self ) = @_;
+	my( $self, $no_embed_js ) = @_; #$no_embed_js is used by the EPScript method when multiple badges could appear on a page
 
-        my $session = $self->{session};
+	my $session = $self->{session};
 
-        my $frag = $session->xml->create_document_fragment;
+	my $frag = $session->xml->create_document_fragment;
 
-        my ( $type, $id ) = $session->call( [ "altmetric", "get_type_and_id" ], $self->{processor}->{eprint} );
+	my ( $type, $id ) = $session->call( [ "altmetric", "get_type_and_id" ], $self->{processor}->{eprint} );
 
-        return $frag if ( !defined $type || !defined $id );
+	return $frag if ( !defined $type || !defined $id );
 
 	# If an API key has been defined, use the API (via local cgi) method to render the data.
 	# If there is no API key, fall back to the Altmetric embed javascript method.
 
 	if( defined $session->config( "altmetric", "api_key" ) )
 	{
-        	my $div = $frag->appendChild( $session->make_element( 'div', id => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
+		my $div = $frag->appendChild( $session->make_element( 'div', class => 'altmetric_summary_page', "data-altmetric-id-type" => $type, "data-altmetric-id" => $id ) );
 
 		my $phr = "default_content";
 		if( $session->get_lang->has_phrase( $self->html_phrase_id( $phr ) ) )
@@ -50,25 +50,85 @@ EOJ
 	}
 	else
 	{
-        	my $div = $session->make_element( 'div',
-			id => 'altmetric_summary_page',
+		my $div = $session->make_element( 'div',
+			class => 'altmetric-embed',
 			"data-altmetric-id-type" => $type,
 			"data-altmetric-id" => $id,
 			( defined $session->config( "altmetric", "badge_attributes" ) ? %{$session->config( "altmetric", "badge_attributes" )} : undef ),
 		);
 		$frag->appendChild( $div );
 
-		my $script = $session->make_element( "script",
-                        src =>( defined $session->config( "altmetric", "embed_url" )
-                                ? $session->config( "altmetric", "embed_url" )
-                                : "https://embed.altmetric.com/assets/embed.js"
-                        ),
-                        type => 'text/javascript',
-                );
-                $frag->appendChild( $script );
+		# add Altmetric's embed script
+		$frag->appendChild( $self->render_embed_script ) unless $no_embed_js;
 	}
 
-        return $frag;
+	return $frag;
 }
 
+sub render_embed_script
+{
+	my( $self ) = @_;
+
+        my $session = $self->{session};
+
+	my $script = $session->make_element( "script",
+		src =>( defined $session->config( "altmetric", "embed_url" )
+			? $session->config( "altmetric", "embed_url" )
+			: "https://embed.altmetric.com/assets/embed.js"
+		),
+		type => 'text/javascript',
+	);
+	return $script;
+}
+
+# These methods may be useful if the badge should be 
+
+package EPrints::Script::Compiled;
+
+sub run_altmetric_badge
+{
+	my( $self, $state, $eprint, $test ) = @_;
+
+	if( !defined $eprint->[0] || ref( $eprint->[0] ) ne "EPrints::DataObj::EPrint" )
+	{
+		$self->runtime_error( "Can only call altmetric_badge() on eprint objects, not " . ref( $eprint->[0] ) );
+	}
+
+	my $processor = EPrints::ScreenProcessor->new(
+		session  => $state->{session},
+		eprint   => $eprint->[0],
+		eprintid => $eprint->[0]->get_id
+	);
+
+	my $box = $state->{session}->plugin( "Screen::EPrint::Box::Altmetric", processor => $processor );
+	if( !defined $box )
+	{
+		$self->runtime_error( "Problem creating Screen::EPrint::Box::Altmetric" );
+	}
+
+	if( $test )
+	{
+		return [ 0, "BOOLEAN" ] if( !defined $box || !$box->can_be_viewed );
+		return [ 1, "BOOLEAN" ];
+	}
+
+	return [ $box->render(1), "XHTML" ]; #don't include embed javascript by default in case this is used on a page that will display multiple badges
+
+}
+
+sub run_altmetric_embed_script
+{
+	my( $self, $state ) = @_;
+
+	#my $box = $state->{session}->plugin( "Screen::EPrint::Box::Altmetric", processor => $processor );
+	#my $box = $state->{session}->plugin( "Screen::EPrint::Box::Altmetric", session => $state->{session} );
+	my $box = $state->{session}->plugin( "Screen::EPrint::Box::Altmetric" );
+
+	if( !defined $box )
+	{
+		$self->runtime_error( "Problem creating Screen::EPrint::Box::Altmetric" );
+	}
+
+	return [ $box->render_embed_script, "XHTML" ];
+}
 1;

--- a/static/javascript/auto/99_altmetric.js
+++ b/static/javascript/auto/99_altmetric.js
@@ -1,6 +1,6 @@
 var EP_Altmetric_Badge = Class.create( {
 
-        initialize: function(id) {
+	initialize: function(id) {
 
 		if( id == null )
 			return;
@@ -16,19 +16,19 @@ var EP_Altmetric_Badge = Class.create( {
 			return;
 
 		this.callback();
-        },
+	},
 
 	callback: function() {
-                new Ajax.Request( eprints_http_cgiroot + "/altmetric?id_type=" + this.altmetric_id_type + "&id=" + this.altmetric_id, {
-                                method: 'get',
-                                onSuccess: this.draw.bind(this),
-                                onFailure: function(response) {  }.bind(this) 
-                }); 
+		new Ajax.Request( eprints_http_cgiroot + "/altmetric?id_type=" + this.altmetric_id_type + "&id=" + this.altmetric_id, {
+				method: 'get',
+				onSuccess: this.draw.bind(this),
+				onFailure: function(response) {  }.bind(this)
+		});
 	},
 
 	draw: function(response) {
 
-                var json = response.responseText.evalJSON();
+		var json = response.responseText.evalJSON();
 
 		if( json.error != null && json.error )
 		{
@@ -41,61 +41,60 @@ var EP_Altmetric_Badge = Class.create( {
 		// get link text displayed before it is replaced by the badge (or use a default value)
 		var linktext = this.element.innerHTML.stripTags().strip().replace(/\n/g,' ').replace(/\s+/g,' ') || "View details on Altmetric's website";
 
+		// v2 returns 'html' value
 		if( json.html != null )
 		{
-			this.element.update( json.html ); 
+			this.element.update( json.html );
 		}
 		else
 		{
-
-		var img = new Element( 'img', { 'src': json.images.medium, 'class': 'altmetric_donut' } );
+			// pre-v2 way of doing things. This has been left in case people have a local copy of the cgi script
+			var img = new Element( 'img', { 'src': json.images.medium, 'class': 'altmetric_donut' } );
 	
-		this.element.update( img ); 
+			this.element.update( img );
 
-		var details_panel = new Element( 'div', { 'class': 'altmetric_details_panel' } );
-		this.element.insert( details_panel );
+			var details_panel = new Element( 'div', { 'class': 'altmetric_details_panel' } );
+			this.element.insert( details_panel );
 
-		/* 2025-06-02 From: https://api.altmetric.com/data-endpoints-counts.html#response-object, 'cited_by_[ ]_counts' available are:
-		  posts (combined total of below?)
-		  delicious, fbwalls, feeds, forum, gplus, linkedin, msm, peer_review_sites, pinners, 
-		  policies, qs, rdts, rh, tweeters, videos, weibo, wikipedia
-		  Any of the above can be added to the array below.
-		*/
-		//var types = [ 'tweeters', 'rdts', 'feeds', 'gplus', 'msm', 'fbwalls', 'videos' ];
-		var types = [ 'fbwalls','feeds','gplus','msm','rdts','qna','tweeters','bluesky','wikipedia','policies','guidelines','patents','videos' ];
-		var data = new Hash( json );
+			/* From: https://api.altmetric.com/data-endpoints-counts.html#response-object, 'cited_by_[ ]_counts' available are:
+			  posts (combined total of below)
+			  fbwalls, feeds, gplus, msm, rdts, qna, tweeters, bluesky, wikipedia, policies, guidelines, patents, videos
+			  Any of the above can be added to the array below.
+			*/
+			var types = [ 'fbwalls','feeds','gplus','msm','rdts','qna','tweeters','bluesky','wikipedia','policies','guidelines','patents','videos' ];
+			var data = new Hash( json );
 
-		for( var i=0; i < types.length; i++ )
-		{
-			var value = data.get( "cited_by_" + types[i] + "_count" );
-			if( value != null )
+			for( var i=0; i < types.length; i++ )
 			{
-				var row = new Element( 'div', { 'class': 'altmetric_row altmetric_' + types[i] } );
-				var figure = new Element( 'span' );
-				figure.update( value );
-				row.update( figure );
-				details_panel.insert( row );
+				var value = data.get( "cited_by_" + types[i] + "_count" );
+				if( value != null )
+				{
+					var row = new Element( 'div', { 'class': 'altmetric_row altmetric_' + types[i] } );
+					var figure = new Element( 'span' );
+					figure.update( value );
+					row.update( figure );
+					details_panel.insert( row );
+				}
 			}
-		}
 
-		details_panel.insert( new Element( 'br' ) );
-        // RM removed as connotea was discontinued in 2013
-        // 'connotea', 
-		var readers = [ 'mendeley','citeulike' ];
-		data = new Hash( json.readers );
-	
-		for( var i=0; i < readers.length; i++ )
-		{
-			var value = data.get( readers[i] );
-			if( ( value != null ) && ( value != 0 ) )
+			details_panel.insert( new Element( 'br' ) );
+			// RM removed as connotea was discontinued in 2013
+			// 'connotea',
+			var readers = [ 'mendeley','citeulike' ];
+			data = new Hash( json.readers );
+
+			for( var i=0; i < readers.length; i++ )
 			{
-				var row = new Element( 'div', { 'class': 'altmetric_row altmetric_' + readers[i] } );
-				var figure = new Element( 'span' );
-				figure.update( value );
-				row.update( figure );
-				details_panel.insert( row );
+				var value = data.get( readers[i] );
+				if( ( value != null ) && ( value != 0 ) )
+				{
+					var row = new Element( 'div', { 'class': 'altmetric_row altmetric_' + readers[i] } );
+					var figure = new Element( 'span' );
+					figure.update( value );
+					row.update( figure );
+					details_panel.insert( row );
+				}
 			}
-		}
 
 		} //end html else
 		

--- a/static/javascript/auto/99_altmetric.js
+++ b/static/javascript/auto/99_altmetric.js
@@ -41,6 +41,13 @@ var EP_Altmetric_Badge = Class.create( {
 		// get link text displayed before it is replaced by the badge (or use a default value)
 		var linktext = this.element.innerHTML.stripTags().strip().replace(/\n/g,' ').replace(/\s+/g,' ') || "View details on Altmetric's website";
 
+		if( json.html != null )
+		{
+			this.element.update( json.html ); 
+		}
+		else
+		{
+
 		var img = new Element( 'img', { 'src': json.images.medium, 'class': 'altmetric_donut' } );
 	
 		this.element.update( img ); 
@@ -48,13 +55,14 @@ var EP_Altmetric_Badge = Class.create( {
 		var details_panel = new Element( 'div', { 'class': 'altmetric_details_panel' } );
 		this.element.insert( details_panel );
 
-		/* 2016-09-01 From: http://api.altmetric.com/docs/call_citations.html, 'types' available are:
+		/* 2025-06-02 From: https://api.altmetric.com/data-endpoints-counts.html#response-object, 'cited_by_[ ]_counts' available are:
 		  posts (combined total of below?)
 		  delicious, fbwalls, feeds, forum, gplus, linkedin, msm, peer_review_sites, pinners, 
 		  policies, qs, rdts, rh, tweeters, videos, weibo, wikipedia
 		  Any of the above can be added to the array below.
 		*/
-		var types = [ 'tweeters', 'rdts', 'feeds', 'gplus', 'msm', 'fbwalls', 'videos' ];
+		//var types = [ 'tweeters', 'rdts', 'feeds', 'gplus', 'msm', 'fbwalls', 'videos' ];
+		var types = [ 'fbwalls','feeds','gplus','msm','rdts','qna','tweeters','bluesky','wikipedia','policies','guidelines','patents','videos' ];
 		var data = new Hash( json );
 
 		for( var i=0; i < types.length; i++ )
@@ -88,6 +96,8 @@ var EP_Altmetric_Badge = Class.create( {
 				details_panel.insert( row );
 			}
 		}
+
+		} //end html else
 		
 		var altlink = new Element( 'a', { 'href': json.details_url + '&domain=' + document.domain, 'class': 'altmetric_details', 'target': '_blank' } );
 		altlink.update( linktext );

--- a/static/style/auto/altmetric.css
+++ b/static/style/auto/altmetric.css
@@ -24,25 +24,45 @@ div.altmetric_row > span {
 	font-weight: bold;
 }
 
-/* Twitter */
+/* Twitter / X 
 div.altmetric_tweeters:before {
-	content: 'Tweeted by ';
+	content: 'Posted by ';
 }
+
+div.altmetric_tweeters:after {
+	content: ' X users';
+}
+*/
 
 div.altmetric_tweeters {
 	border-left: 16px solid #74CFED;
 }
 
-/* Blogs */
+/* Bluesky 
+div.altmetric_bluesky:before {
+	content: 'Mentioned by ';
+}
+
+div.altmetric_bluesky:after {
+	content: ' bluesky users';
+}
+*/
+
+div.altmetric_bluesky {
+	border-left: 16px solid #1185FE;
+}
+
+/* Blogs 
 div.altmetric_feeds:before {
 	content: 'Blogged by ';
 }
+*/
 
 div.altmetric_feeds {
 	border-left: 16px solid #FFD140;
 }
 
-/* Google+ */
+/* Google+ 
 div.altmetric_gplus:before {
 	content: 'Mentioned in ';
 }
@@ -50,12 +70,13 @@ div.altmetric_gplus:before {
 div.altmetric_gplus:after {
 	content: ' Google+ posts';
 }
+*/
 
 div.altmetric_gplus {
 	border-left: 16px solid #E065BB;
 }
 
-/* News outlet */
+/* News outlet
 div.altmetric_msm:before {
 	content: 'Picked up by ';
 }
@@ -63,12 +84,13 @@ div.altmetric_msm:before {
 div.altmetric_msm:after {
 	content: ' news outlets';
 }
+*/
 
 div.altmetric_msm {
 	border-left: 16px solid #FF0000;
 }
 
-/* Facebook */
+/* Facebook
 div.altmetric_fbwalls:before {
 	content: 'On ';
 }
@@ -76,25 +98,23 @@ div.altmetric_fbwalls:before {
 div.altmetric_fbwalls:after {
 	content: ' Facebook pages';
 }
+*/
 
 div.altmetric_fbwalls {
 	border-left: 16px solid #2445BD;
 }
 
-/* Reddit */
+/* Reddit
 div.altmetric_rdts:before {
 	content: 'Reddited by ';
 }
+*/
 
 div.altmetric_rdts {
 	border-left: 16px solid #D5E8F0;
 }
 
-/* Delicious */
-
-/* Forum */
-
-/* Videos */
+/* Videos 
 div.altmetric_videos:before {
 	content: 'On ';
 }
@@ -102,33 +122,37 @@ div.altmetric_videos:before {
 div.altmetric_videos:after {
 	content: ' videos';
 }
+*/
 
 div.altmetric_videos {
 	border-left: 16px solid #98C973;
 }
 
-/* Mendeley */
+/* Mendeley
 div.altmetric_mendeley:after {
 	content: ' readers on Mendeley';
 }
+*/
 
 div.altmetric_mendeley {
 	border-left: 16px solid #A60000;
 }
 
-/* Connotea */
+/* Connotea
 div.altmetric_connotea:after {
 	content: ' readers on Connotea';
 }
+*/
 
 div.altmetric_connotea {
 	border-left: 16px solid #FF4040;
 }
 
-/* CiteULike */
+/* CiteULike
 div.altmetric_citeulike:after {
 	content: ' readers on CiteULike ';
 }
+*/
 
 div.altmetric_citeulike {
 	border-left: 16px solid #BCD2EF;

--- a/static/style/auto/altmetric.css
+++ b/static/style/auto/altmetric.css
@@ -1,4 +1,4 @@
-#altmetric_summary_page {
+.altmetric_summary_page {
 	padding: 10px;
 }
 

--- a/static/style/auto/altmetric.css
+++ b/static/style/auto/altmetric.css
@@ -24,136 +24,81 @@ div.altmetric_row > span {
 	font-weight: bold;
 }
 
-/* Twitter / X 
-div.altmetric_tweeters:before {
-	content: 'Posted by ';
-}
-
-div.altmetric_tweeters:after {
-	content: ' X users';
-}
-*/
-
+/* Twitter / X */
 div.altmetric_tweeters {
-	border-left: 16px solid #74CFED;
+	border-left: 16px solid #2F90B9;
 }
 
-/* Bluesky 
-div.altmetric_bluesky:before {
-	content: 'Mentioned by ';
-}
-
-div.altmetric_bluesky:after {
-	content: ' bluesky users';
-}
-*/
-
+/* Bluesky */
 div.altmetric_bluesky {
 	border-left: 16px solid #1185FE;
 }
 
-/* Blogs 
-div.altmetric_feeds:before {
-	content: 'Blogged by ';
-}
-*/
-
+/* Blogs */
 div.altmetric_feeds {
-	border-left: 16px solid #FFD140;
+	border-left: 16px solid #E89500;
 }
 
-/* Google+ 
-div.altmetric_gplus:before {
-	content: 'Mentioned in ';
-}
-
-div.altmetric_gplus:after {
-	content: ' Google+ posts';
-}
-*/
-
+/* Google+ */
 div.altmetric_gplus {
-	border-left: 16px solid #E065BB;
+	border-left: 16px solid #912470;
 }
 
-/* News outlet
-div.altmetric_msm:before {
-	content: 'Picked up by ';
-}
-
-div.altmetric_msm:after {
-	content: ' news outlets';
-}
-*/
-
+/* News outlet */
 div.altmetric_msm {
-	border-left: 16px solid #FF0000;
+	border-left: 16px solid #B60000;
 }
 
-/* Facebook
-div.altmetric_fbwalls:before {
-	content: 'On ';
-}
-
-div.altmetric_fbwalls:after {
-	content: ' Facebook pages';
-}
-*/
-
+/* Facebook */
 div.altmetric_fbwalls {
-	border-left: 16px solid #2445BD;
+	border-left: 16px solid #0B2CA4;
 }
 
-/* Reddit
-div.altmetric_rdts:before {
-	content: 'Reddited by ';
-}
-*/
-
+/* Reddit */
 div.altmetric_rdts {
-	border-left: 16px solid #D5E8F0;
+	border-left: 16px solid #B9DDEB;
 }
 
-/* Videos 
-div.altmetric_videos:before {
-	content: 'On ';
-}
-
-div.altmetric_videos:after {
-	content: ' videos';
-}
-*/
-
+/* Videos */
 div.altmetric_videos {
 	border-left: 16px solid #98C973;
 }
 
-/* Mendeley
-div.altmetric_mendeley:after {
-	content: ' readers on Mendeley';
+/* Q and A */
+div.altmetric_qna {
+        border-left: 16px solid #EFEFEF;
 }
-*/
 
+/* Wikipedia */
+div.altmetric_wikipedia {
+	border-left: 16px solid #3B2A3D;
+}
+
+/* Policies */
+div.altmetric_policies {
+	border-left: 16px solid #5B17E8;
+}
+
+/* Clinical guidelines */
+div.altmetric_guidelines {
+	border-left: 16px solid #15BABC;
+}
+/* Patents*/
+div.altmetric_patents {
+	border-left: 16px solid #D45029;
+}
+
+/* Mendeley */
 div.altmetric_mendeley {
 	border-left: 16px solid #A60000;
 }
 
-/* Connotea
-div.altmetric_connotea:after {
-	content: ' readers on Connotea';
-}
-*/
-
+/* Connotea */
 div.altmetric_connotea {
 	border-left: 16px solid #FF4040;
 }
 
-/* CiteULike
-div.altmetric_citeulike:after {
-	content: ' readers on CiteULike ';
-}
-*/
-
+/* CiteULike */
 div.altmetric_citeulike {
 	border-left: 16px solid #BCD2EF;
 }

--- a/static/style/auto/altmetric.css
+++ b/static/style/auto/altmetric.css
@@ -66,7 +66,7 @@ div.altmetric_videos {
 
 /* Q and A */
 div.altmetric_qna {
-        border-left: 16px solid #EFEFEF;
+	border-left: 16px solid #EFEFEF;
 }
 
 /* Wikipedia */


### PR DESCRIPTION
Fixes #15 , #16  and #17 

Plugin will now fall-back to Altmetric 'embed' method of displaying a badge if no API key is present.

Additional methods have been added to EPScript to (i) add embed javascript and (ii) support multiple badges on one page if e.g. used on a view/search results page.